### PR TITLE
Omit `severity` for removing the warning from prettier

### DIFF
--- a/stylelint-prettier.js
+++ b/stylelint-prettier.js
@@ -69,7 +69,7 @@ module.exports = stylelint.createPlugin(
         {},
         initialOptions,
         prettierRcOptions,
-        stylelintPrettierOptions,
+        omitStylelintSpecificOptions(stylelintPrettierOptions),
         {filepath}
       );
       const prettierSource = prettier.format(source, prettierOptions);
@@ -161,6 +161,12 @@ module.exports = stylelint.createPlugin(
     };
   }
 );
+
+function omitStylelintSpecificOptions(options) {
+  const prettierOptions = Object.assign({}, options);
+  delete prettierOptions.severity;
+  return prettierOptions;
+}
 
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/stylelint-prettier.js
+++ b/stylelint-prettier.js
@@ -164,6 +164,7 @@ module.exports = stylelint.createPlugin(
 
 function omitStylelintSpecificOptions(options) {
   const prettierOptions = Object.assign({}, options);
+  delete prettierOptions.message;
   delete prettierOptions.severity;
   return prettierOptions;
 }

--- a/test/stylelint-prettier.test.js
+++ b/test/stylelint-prettier.test.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const rule = require('..');
+const stylelint = require('stylelint');
 
 // Reading from default .prettierrc
 testRule(rule, {
@@ -503,6 +504,53 @@ testRule(rule, {
       column: 14,
     },
   ],
+});
+
+describe('stylelint configurations', () => {
+  const oldWarn = console.warn;
+  beforeEach(() => {
+    console.warn = jest.fn(console.warn);
+  });
+
+  afterEach(() => {
+    console.warn = oldWarn;
+  });
+
+  it("doesn't raise prettier warnings on `message`", () => {
+    const linted = stylelint.lint({
+      code: ``,
+      config: {
+        plugins: ['./'],
+        rules: {
+          'prettier/prettier': [true, {message: 'welp'}],
+        },
+      },
+    });
+
+    return linted.then(() => {
+      expect(console.warn).not.toHaveBeenCalledWith(
+        expect.stringMatching(/ignored unknown option.+message/i)
+      );
+    });
+  });
+
+  it("doesn't raise prettier warnings on `severity`", () => {
+    const linted = stylelint.lint({
+      code: ``,
+      config: {
+        plugins: ['./'],
+        rules: {
+          'prettier/prettier': [true, {severity: 'warning'}],
+        },
+      },
+    });
+
+    return linted.then(() => {
+      expect(console.warn).not.toHaveBeenCalledWith(
+        expect.stringMatching(/ignored unknown option.+severity/i)
+      );
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
Hey! Thanks for this package 😸 

Right now, all options are passed automatically right from the `stylelint-prettier` rule into prettier itself.
That causes a warning if you pass something that is related to stylelint only, like `severity`, So the following line actually raises a warning:

```json
{
  "rules": {
    "prettier/prettier": [true, { "severity": "warning" }]
  }
}
```

This warning can be avoided, so this PR fixes it by omitting `severity`. Figuring out which keys should be allowed may be problematic if Prettier will change its API, but I guess that `severity` is something that won't be there anyway because it's not a linter.

What do you think?

😸 