### PR TITLE
Fix error when calling stylelint with --syntax and --fix

### DIFF
--- a/stylelint-prettier.js
+++ b/stylelint-prettier.js
@@ -121,10 +121,13 @@ module.exports = stylelint.createPlugin(
           );
         }, root.source.input.css);
 
-        const newRoot = root.source.syntax.parse(
-          rawData,
-          root.source.input.opts
-        );
+        // If root.source.syntax exists then it means stylelint had to use
+        // postcss-syntax to guess the postcss parser that it should use based
+        // upon the input filename.
+        // In that case we want to use the parser that postcss-syntax picked.
+        // Otherwise use the syntax parser that was provided in the options
+        const syntax = root.source.syntax || result.opts.syntax;
+        const newRoot = syntax.parse(rawData);
 
         // For reasons I don't really undersand, when the original input does
         // not have a trailing newline, newRoot generates a trailing newline but

--- a/test/stylelint-prettier.test.js
+++ b/test/stylelint-prettier.test.js
@@ -506,6 +506,31 @@ testRule(rule, {
   ],
 });
 
+// Passing a syntax works
+testRule(rule, {
+  ruleName: rule.ruleName,
+  config: [true, {parser: 'scss'}],
+  syntax: 'scss',
+  fix: true,
+
+  accept: [
+    {
+      description: 'Prettier Scss Valid - Setting Explicit Parser',
+      code: `// I am a scss-specific comment\n$foo: ();\n`,
+    },
+  ],
+  reject: [
+    {
+      description: 'Prettier Scss Invalid - Setting Explicit Parser',
+      code: `// I am a scss-specific comment\n  $foo:();`,
+      fixed: `// I am a scss-specific comment\n$foo: ();\n`,
+      message: `Replace "··$foo:();" with "$foo:·();⏎" (prettier/prettier)`,
+      line: 1,
+      column: 33,
+    },
+  ],
+});
+
 describe('stylelint configurations', () => {
   const oldWarn = console.warn;
   beforeEach(() => {


### PR DESCRIPTION
Prior to this commit setting an explicit syntax when autofixing would
cause a crash as we were assuming we had access to values injected by
postcss-syntax at all times.

Check of the existence of the parser that postcss-syntax provides, and
if that is not present then use the one specified in the options

Fixes #8

//cc @lydell Can you give this branch a try to see if it fixes your issues?

We're still relying on an implementation detail of postcss-syntax (i.e. that it adds `root.source.syntax`), but I think this is the best I can do given the current stylelint API. Otherwise stylelint would have to expose `getPostcssResult` as part of its public API which feels like it opens up a large bag of worms.
