### PR TITLE
Add stylelint peer dependency for yarn PNP compatiblity

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "prettier-linter-helpers": "^1.0.0"
   },
   "peerDependencies": {
-    "prettier": ">= 0.11.0"
+    "prettier": ">= 0.11.0",
+    "stylelint": "^8.0.0 || ^9.0.0 || ^10.0.0"
   },
   "devDependencies": {
     "eslint": "^5.0.1",


### PR DESCRIPTION
Hello,

I'm trying to integrate stylelint-prettier inside my build tool ([Crafty](https://github.com/swissquote/crafty/tree/stylelint-prettier)) And as this tool is tested to work against Yarn PNP it currently fails as there is no dependency or peer dependency to stylelint.

To make this pull request I took example from the `stylelint-scss` plugin : https://github.com/kristerkari/stylelint-scss/blob/master/package.json#L47