### PR TITLE
Make sure we don't explode on Vue and css-in-js solutions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,6 @@
 !.eslintrc.js
 node_modules
+
+# Ignore everything in the fixtures dir except the stylelint config
+test/fixtures
+!test/fixtures/stylelint.config.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,5 +7,6 @@ module.exports = {
   root: true,
   rules: {
     'node/no-unpublished-require': ['error', {allowModules: ['stylelint']}],
+    'node/no-missing-require': ['error', {allowModules: ['styled-components']}],
   },
 };

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,6 +22,19 @@ Linting is ran as part of `yarn run test`. The build will fail if there are any 
 
 This plugin is used to lint itself. The style is checked when `npm test` is run, and the build will fail if there are any linting errors. You can use `npm run lint -- --fix` to fix some linting errors. To run the tests without running the linter, you can use `node_modules/.bin/mocha`.
 
+### End to end tests
+
+e2e test fixtures are in `test/fixtures`.
+
+Running the e2e tests while trying to debug a problem can be annoying. To check
+stylelint's output of a single fixture, run stylelint from within the fixtures
+directory:
+
+```sh
+cd test/fixtures
+../../node_modules/.bin/stylelint 'check*'
+```
+
 ## Publishing
 
 - Ensure you are on the master branch locally.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 package.json
-test-e2e
+test/fixtures
 
 # this file doesn't exist, but we use it as a filename that should be ignored
 # by prettier in the tests

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-prettier": "^3.0.0",
     "jest": "^23.6.0",
-    "prettier": "^1.13.7",
+    "prettier": "^1.17.0",
     "stylelint": "^9.5.0",
     "stylelint-config-prettier": "^4.0.0"
   },

--- a/stylelint-prettier.js
+++ b/stylelint-prettier.js
@@ -67,6 +67,29 @@ module.exports = stylelint.createPlugin(
         initialOptions.parser = 'css';
       }
 
+      // Stylelint suppports languages that may contain multiple types of style
+      // languages, thus we can't rely on guessing the parser based off the
+      // filename.
+
+      // In all of the following cases stylelint extracts a part of a file to
+      // be formatted and there exists a prettier parser for the whole file.
+      // If you're interested in prettier you'll want a fully formatted file so
+      // you're about to run prettier over the whole file anyway.
+      // Therefore running prettier over just the style section is wasteful, so
+      // skip it.
+
+      const parserBlockList = [
+        'babel',
+        'flow',
+        'typescript',
+        'vue',
+        'markdown',
+        'html',
+      ];
+      if (parserBlockList.indexOf(prettierFileInfo.inferredParser) !== -1) {
+        return;
+      }
+
       const prettierOptions = Object.assign(
         {},
         initialOptions,

--- a/test/fixtures/check.inert.html
+++ b/test/fixtures/check.inert.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Page Title</title>
+    <style>
+      .foo {
+        background-image: url("x");
+      }
+    </style>
+
+    <style lang="scss">
+      .foo {
+        background-image: url("x");
+      }
+
+      $map: (
+        'alpha': 10,
+        'beta': 20,
+        'gamma': 30
+      );
+    </style>
+  </head>
+
+  <body></body>
+</html>

--- a/test/fixtures/check.inert.js
+++ b/test/fixtures/check.inert.js
@@ -1,0 +1,11 @@
+const styled = require('styled-components');
+
+const Button = styled.div`
+  background-image: url("x");
+  color: red;
+`;
+
+const Button2 = styled.div({
+  backgroundImage: 'url("x")',
+  color: 'red',
+});

--- a/test/fixtures/check.inert.md
+++ b/test/fixtures/check.inert.md
@@ -1,0 +1,19 @@
+# TEST
+
+```css
+h2 {
+  background-image: url("x");
+}
+```
+
+```scss
+h2 {
+  background-image: url("x");
+}
+
+$map: (
+  'alpha': 10,
+  'beta': 20,
+  'gamma': 30
+);
+```

--- a/test/fixtures/check.inert.vue
+++ b/test/fixtures/check.inert.vue
@@ -1,0 +1,21 @@
+<template>
+  <span>Hi</span>
+</template>
+
+<style>
+.foo {
+  background-image: url("x");
+}
+</style>
+
+<style lang="scss">
+.foo {
+  background-image: url("x");
+}
+
+$map: (
+  'alpha': 10,
+  'beta': 20,
+  'gamma': 30
+);
+</style>

--- a/test/fixtures/check.invalid.css
+++ b/test/fixtures/check.invalid.css
@@ -1,0 +1,3 @@
+.foo {
+  background-image: url("x");
+}

--- a/test/fixtures/check.invalid.scss
+++ b/test/fixtures/check.invalid.scss
@@ -1,0 +1,9 @@
+.foo {
+  background-image: url("x");
+}
+
+$map: (
+  'alpha': 10,
+  'beta': 20,
+  'gamma': 30
+);

--- a/test/fixtures/check.unparsable.js
+++ b/test/fixtures/check.unparsable.js
@@ -1,0 +1,7 @@
+const styled = require('styled-components');
+
+const But{ton = styled.div`
+  background-image: url("x");
+  color: red;
+`;
+

--- a/test/fixtures/stylelint.config.js
+++ b/test/fixtures/stylelint.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: [`../..`],
+  extends: ['stylelint-config-prettier'],
+  rules: {
+    'prettier/prettier': [true, {singleQuote: true, trailingComma: 'all'}],
+  },
+};

--- a/test/stylelint-prettier-e2e.test.js
+++ b/test/stylelint-prettier-e2e.test.js
@@ -1,0 +1,54 @@
+const {spawnSync} = require('child_process');
+const {resolve} = require('path');
+
+describe('E2E Tests', () => {
+  test('CSS/SCSS files', () => {
+    const result = runStylelint('*.{css,scss}');
+
+    const expectedResult = `
+check.invalid.css
+ 2:25  ✖  Replace ""x"" with "'x'"   prettier/prettier
+
+check.invalid.scss
+ 2:25  ✖  Replace ""x"" with "'x'"   prettier/prettier
+ 8:14  ✖  Insert ","                 prettier/prettier
+`.trim();
+
+    expect(result.output).toEqual(expectedResult);
+    expect(result.status).toEqual(2);
+  });
+
+  test('HTML/Markdown/Vue files', () => {
+    const result = runStylelint('*.{html,md,vue}');
+
+    const expectedResult = ``;
+
+    expect(result.output).toEqual(expectedResult);
+    expect(result.status).toEqual(0);
+  });
+
+  /**
+   * Don't act upon CSS-in-JS files
+   */
+  test('CSS-in-JS files', () => {
+    const result = runStylelint('*.js');
+
+    const expectedResult = ``;
+
+    expect(result.output).toEqual(expectedResult);
+    expect(result.status).toEqual(0);
+  });
+});
+
+function runStylelint(pattern) {
+  const stylelintCmd = resolve(`${__dirname}/../node_modules/.bin/stylelint`);
+
+  const result = spawnSync(stylelintCmd, [pattern], {
+    cwd: `${__dirname}/fixtures`,
+  });
+
+  return {
+    status: result.status,
+    output: result.stdout.toString().trim(),
+  };
+}

--- a/test/stylelint-prettier.test.js
+++ b/test/stylelint-prettier.test.js
@@ -530,30 +530,6 @@ testRule(rule, {
   ],
 });
 
-// Invalid syntax is reported
-testRule(rule, {
-  ruleName: rule.ruleName,
-  config: [true, {trailingComma: 'all'}],
-  codeFilename: filename('default', 'dummy.js'),
-  accept: [],
-  reject: [
-    {
-      description: 'Prettier JS Invalid - Unparsable code',
-      code: `cons}t Button = styled.button\`\n  background: tomato;\n\`;`,
-      message: `Parsing error: Unexpected token`,
-      line: 1,
-      column: 5,
-    },
-    {
-      description: 'Prettier JS Invalid - Unparsable code',
-      code: `const f = 1;\nconst bar = 3;\n\nco}nst Button = styled.button\`\n  background: tomato;\n\`;`,
-      message: `Parsing error: Unexpected token`,
-      line: 4,
-      column: 3,
-    },
-  ],
-});
-
 describe('stylelint configurations', () => {
   const oldWarn = console.warn;
   beforeEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3460,9 +3460,9 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.13.7:
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
+prettier@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
 
 pretty-format@^23.6.0:
   version "23.6.0"


### PR DESCRIPTION
Stylelint 9.10.0 uses postcss-jsx to parse css-in-js solutions and postcss-html to parse vue/markdown/html files. These two together mean the embedded languages landscape is a lot cleaner than a few months ago in the days of 9.2.1.

However stylelint 9.9 to 9.10 changed how these embedded languages were passed into rules. In 9.9 the whole file content was available in `root.source.input` (i.e. a whole html or vue file, including all surrounding html tags tags). In 9.10 only the contents of style language fragments are available (i.e. only the content of each of the `<style>` tags gets passed to the rule).

This means that we can run stylelint with stylelint-prettier over these embedded language files, but it'll only prettify the style portions. If you're this interested in prettier then you probably want to run prettier over the rest of the file too to get it fully formatted. Thus it seems pointless to duplicate that work of running prettier within stylelint.

So stop running prettier over this handful of languages that can have style languages embedded into them.

This also adds a handful of e2e tests as which allow us to keep testing the embedded language end-to-end.

Fixes #18, #15 and #12.