### PR TITLE
Correct EOL handling for UNIX and Windows

### DIFF
--- a/stylelint-prettier.js
+++ b/stylelint-prettier.js
@@ -191,8 +191,8 @@ module.exports = stylelint.createPlugin(
         root.append(newRoot);
 
         // Use the EOL whitespace from the rawData, as it could be \n or \r\n
-        const trailingWhitespace = rawData.match(/[\s\uFEFF\xA0]+$/)[0];
-        if (trailingWhitespace.length) {
+        const trailingWhitespace = rawData.match(/[\s\uFEFF\xA0]+$/);
+        if (trailingWhitespace) {
           root.raws.after = trailingWhitespace[0];
         }
         return;

--- a/test/stylelint-prettier.test.js
+++ b/test/stylelint-prettier.test.js
@@ -530,6 +530,41 @@ testRule(rule, {
   ],
 });
 
+// EOL Tests
+testRule(rule, {
+  ruleName: rule.ruleName,
+  config: true,
+  fix: true,
+  accept: [
+    {
+      description: 'Prettier EOL Valid - UNIX',
+      code: `body {\n  font-size: 12px;\n}\np {\n  color: 'black';\n}\n`,
+    },
+    {
+      description: 'Prettier EOL Valid - Windows',
+      code: `body {\r\n  font-size: 12px;\r\n}\r\np {\r\n  color: 'black';\r\n}\r\n`,
+    },
+  ],
+  reject: [
+    {
+      description: 'Prettier EOL Invalid - UNIX',
+      code: `body {\n  font-size: 12px;\n}\np {\n  color: 'black';\n}`,
+      fixed: `body {\n  font-size: 12px;\n}\np {\n  color: 'black';\n}\n`,
+      message: `Insert \"⏎\" (prettier/prettier)`,
+      line: 6,
+      column: 2,
+    },
+    {
+      description: 'Prettier EOL Invalid - Windows',
+      code: `body {\r\n  font-size: 12px;\r\n}\r\np {\r\n  color: 'black';\r\n}`,
+      fixed: `body {\r\n  font-size: 12px;\r\n}\r\np {\r\n  color: 'black';\r\n}\r\n`,
+      message: `Insert \"␍⏎\" (prettier/prettier)`,
+      line: 6,
+      column: 2,
+    },
+  ],
+});
+
 describe('stylelint configurations', () => {
   const oldWarn = console.warn;
   beforeEach(() => {


### PR DESCRIPTION
This PR fixes the incorrect EOL handling at the End of File on Windows #23.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#Return_value) `match `will return `null` if nothing matches. In this case, `trailingWhitespace[0]` accessed only the first character of `\r\n`.

I've added tests to cover those cases and prevent regression.

I've also applied the fix to the Repository https://github.com/rzontar/stylelint-prettier-cr/tree/fix and verified the results.