### PR TITLE
Remove Node 8 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 cache: yarn
 node_js:
-  - '8'
   - '10'
   - '12'
 env:


### PR DESCRIPTION
Node 8 is no longer supported so makes sense to remove it here