### PR TITLE
Simplify integration with the recommended rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,13 @@ Then, in your `.stylelintrc`:
 
 ## Recommended Configuration
 
-This plugin works best if you disable all other Stylelint rules relating to code formatting, and only enable rules that detect patterns in the AST. (If another active Stylelint rule disagrees with `prettier` about how code should be formatted, it will be impossible to avoid lint errors.) You can use [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier) to disable all formatting-related Stylelint rules.
+This plugin works best if you disable all other Stylelint rules relating to code formatting, and only enable rules that detect patterns in the AST. (If another active Stylelint rule disagrees with `prettier` about how code should be formatted, it will be impossible to avoid lint errors.)
 
 If your desired formatting does not match the `prettier` output, you should use a different tool such as [prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint) instead.
 
 To integrate this plugin with `stylelint-config-prettier`, you can use the `"recommended"` configuration:
 
-1.  In addition to the above installation instructions, install `stylelint-config-prettier`:
-
-    ```sh
-    npm install --save-dev stylelint-config-prettier
-    ```
-
-2.  Then replace the plugins and rules declarations in your `.stylelintrc` that you added in the prior section with:
+1.  Replace the plugins and rules declarations in your `.stylelintrc` that you added in the prior section with:
 
     ```json
     {
@@ -78,6 +72,8 @@ This does three things:
 3.  Extends the `stylelint-config-prettier` configuration.
 
 You can then set Prettier's own options inside a `.prettierrc` file.
+
+You can alternatively use [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier) to disable all formatting-related Stylelint rules.
 
 ## Options
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "homepage": "https://github.com/prettier/stylelint-prettier#readme",
   "dependencies": {
-    "prettier-linter-helpers": "^1.0.0"
+    "prettier-linter-helpers": "^1.0.0",
+    "stylelint-config-prettier": "^7.0.0"
   },
   "peerDependencies": {
     "prettier": ">= 0.11.0",
@@ -43,8 +44,7 @@
     "jest": "^24.9.0",
     "prettier": "^1.19.1",
     "strip-ansi": "^6.0.0",
-    "stylelint": "^9.5.0",
-    "stylelint-config-prettier": "^7.0.0"
+    "stylelint": "^9.5.0"
   },
   "engines": {
     "node": ">=6"

--- a/recommended.js
+++ b/recommended.js
@@ -1,5 +1,5 @@
 module.exports = {
   plugins: ['.'],
-  extends: ['stylelint-config-prettier'],
+  extends: [require.resolve('stylelint-config-prettier')],
   rules: {'prettier/prettier': true},
 };


### PR DESCRIPTION
The current setup forces users to include 2 dependencies. I think this is adding a lot of overhead when all the needs could be included within this package.

Making `stylelint-config-prettier` a dependency means users can now rely on a single package and receive everything built-in with this single package.

I think this is likely the most common setup for all users. The tradeoff is that install `stylelint-prettier` now always includes the config. But that's only a few extra kbs for people not using both the plugin and the config, so it seemed worthwhile to me.