### PR TITLE
Skip processing angular and svelte files

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,11 @@
     "eslint-plugin-prettier": "^3.1.1",
     "jest": "^24.9.0",
     "prettier": "^1.19.1",
+    "prettier-plugin-svelte": "^2.1.6",
     "strip-ansi": "^6.0.0",
     "stylelint": "^9.5.0",
-    "stylelint-config-prettier": "^7.0.0"
+    "stylelint-config-prettier": "^7.0.0",
+    "svelte": "^3.34.0"
   },
   "engines": {
     "node": ">=6"

--- a/stylelint-prettier.js
+++ b/stylelint-prettier.js
@@ -94,6 +94,8 @@ module.exports = stylelint.createPlugin(
         'vue',
         'markdown',
         'html',
+        'angular', // .component.html files
+        'svelte',
       ];
       if (parserBlockList.indexOf(prettierFileInfo.inferredParser) !== -1) {
         return;

--- a/test/fixtures/check.inert.component.html
+++ b/test/fixtures/check.inert.component.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Page Title</title>
+    <style>
+      .foo {
+        background-image: url("x");
+      }
+    </style>
+  </head>
+
+  <body>
+    <p class="mb-0" style="font-size: 12px; background-color: red;">Hi</p>
+  </body>
+</html>

--- a/test/fixtures/check.inert.svelte
+++ b/test/fixtures/check.inert.svelte
@@ -1,0 +1,12 @@
+<span>Hi</span>
+
+<style lang="scss">
+.foo {
+  background-image: url("x")
+}
+$map: (
+  'alpha': 10,
+  'beta': 20,
+  'gamma': 30
+)
+</style>

--- a/test/stylelint-prettier-e2e.test.js
+++ b/test/stylelint-prettier-e2e.test.js
@@ -38,8 +38,8 @@ check.invalid.scss
    * Don't act upon html-like files, as prettier already handles them as whole
    * files
    */
-  test('HTML/Markdown/Vue files', () => {
-    const result = runStylelint('*.{html,md,vue}');
+  test('HTML/Markdown/Vue/Svelte files', () => {
+    const result = runStylelint('*.{html,md,vue,svelte}');
 
     const expectedResult = ``;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3561,6 +3561,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier-plugin-svelte@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.1.6.tgz#ae10e16d89c94c72a937574eb840501104ff4565"
+  integrity sha512-eg6MhH394IYsljIcLMgCx/wozObkUFZJ1GkH+Nj8sZQilnNCFTeSBcEohBaNa9hr5RExvlJQJ8a2CEjMMrwL8g==
+
 prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
@@ -4332,6 +4337,11 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+svelte@^3.34.0:
+  version "3.34.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.34.0.tgz#a0195a0db0305d78df87520711317b99e6fb8a26"
+  integrity sha512-xWcaQ/J4Yd5k0UWz+ef6i5RW5WP3hNpluEI2qtTTKlMOXERHpVL509O9lIw7sgEn1JjJgTOS+lnnDj99vQ3YqQ==
 
 svg-tags@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
prettier already takes care of formatting these whole files, so skip
them, just like js/markdown/html/vue files (see #22)

With thanks to @JounQin who investigated this in #156
