### PR TITLE
chore: remove double word "the"

### DIFF
--- a/stylelint-prettier.js
+++ b/stylelint-prettier.js
@@ -204,7 +204,7 @@ module.exports = stylelint.createPlugin(
         return;
       }
 
-      // Report in the the order the differences appear in the content
+      // Report in the order the differences appear in the content
       differences.forEach((difference) => {
         switch (difference.operation) {
           case INSERT:


### PR DESCRIPTION
Minor doc issue I noticed trying to trace back a config issue by looking at the source for the plugin