### PR TITLE
chore: add Dependabot and update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: 'monthly'
     open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -15,12 +15,13 @@ jobs:
         node-version: [16.x, 14.x, 12.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
 
       - name: Use Stylelint ${{ matrix.stylelint-version }}
         run: yarn upgrade stylelint@${{ matrix.stylelint-version }}


### PR DESCRIPTION
Some of the built-in actions have new major versions. setup-node now includes dependeny caching, so added that.
To prevent them falling behind next time, added the Dependabot config