### PR TITLE
Handle case where no prettier config is present

### DIFF
--- a/stylelint-prettier.js
+++ b/stylelint-prettier.js
@@ -56,7 +56,7 @@ module.exports = stylelint.createPlugin(
       const prettierFileInfo = await prettier.getFileInfo(filepath, {
         resolveConfig: true,
         plugins:
-          prettierRcOptions.plugins ?? stylelintPrettierOptions.plugins ?? [],
+          prettierRcOptions?.plugins ?? stylelintPrettierOptions?.plugins ?? [],
         ignorePath: '.prettierignore',
       });
 


### PR DESCRIPTION
Fixes #310.

Handle the case where `prettierRcOptions` returns null when no prettier config or editorconfig is present when curating a plugins list.