### PR TITLE
Add astro components to parser blocklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "postcss-styled-syntax": "^0.4.0",
     "postcss-syntax": "^0.36.2",
     "prettier": "^3.0.0",
+    "prettier-plugin-astro": "^0.12.1",
     "prettier-plugin-svelte": "^3.0.0",
     "strip-ansi": "^6.0.0",
     "stylelint": "^15.8.0",

--- a/stylelint-prettier.js
+++ b/stylelint-prettier.js
@@ -95,6 +95,7 @@ module.exports = stylelint.createPlugin(
         'html',
         'angular', // .component.html files
         'svelte',
+        'astro',
       ];
       if (parserBlockList.indexOf(prettierFileInfo.inferredParser) !== -1) {
         return;

--- a/test/fixtures/check.inert.astro
+++ b/test/fixtures/check.inert.astro
@@ -1,0 +1,26 @@
+---
+interface Props {
+  title: string;
+  body: string;
+  href: string;
+}
+
+const { href, title, body } = Astro.props;
+---
+
+<li class="link-card">
+  <a href={href}>
+    <h2>
+      {title}
+      <span>&rarr;</span>
+    </h2>
+    <p>
+      {body}
+    </p>
+  </a>
+</li>
+<style>
+  .link-card {
+    background-color: #23262d;
+  }
+</style>

--- a/test/fixtures/stylelint.config.js
+++ b/test/fixtures/stylelint.config.js
@@ -6,7 +6,7 @@ module.exports = {
       {
         singleQuote: true,
         trailingComma: 'all',
-        plugins: ['prettier-plugin-svelte'],
+        plugins: ['prettier-plugin-svelte', 'prettier-plugin-astro'],
       }
     ],
   },
@@ -20,7 +20,7 @@ module.exports = {
       customSyntax: 'postcss-styled-syntax',
     },
     {
-      files: ['**/*.{html,svelte,vue}'],
+      files: ['**/*.{html,svelte,vue,astro}'],
       customSyntax: 'postcss-html',
     },
     {

--- a/test/stylelint-prettier-e2e.test.js
+++ b/test/stylelint-prettier-e2e.test.js
@@ -44,8 +44,8 @@ check.invalid.scss
    * Don't act upon html-like files, as prettier already handles them as whole
    * files
    */
-  test('HTML/Markdown/Vue/Svelte files', () => {
-    const result = runStylelint('*.{html,md,vue,svelte}');
+  test('HTML/Markdown/Vue/Svelte/Astro files', () => {
+    const result = runStylelint('*.{html,md,vue,svelte,astro}');
 
     const expectedResult = ``;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,11 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@astrojs/compiler@^1.5.5":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-1.8.2.tgz#f305d5724c45a9932a8ef4e87b2e7227d15d1c2b"
+  integrity sha512-o/ObKgtMzl8SlpIdzaxFnt7SATKPxu4oIP/1NL+HDJRzxfJcAkOTAb/ZKMRyULbz4q+1t2/DAebs2Z1QairkZw==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -3093,6 +3098,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier-plugin-astro@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-astro/-/prettier-plugin-astro-0.12.1.tgz#246140cf10454fcd1e93850c499118aee67d4a39"
+  integrity sha512-1mlNIU/cV+25oB4z5wXzOz2fSDcawG3MsVUwgw2i8VSy7voLSENMSpR1juu3U5MAVUo3owuyax11QuylbpuqOQ==
+  dependencies:
+    "@astrojs/compiler" "^1.5.5"
+    prettier "^3.0.0"
+    sass-formatter "^0.7.6"
+
 prettier-plugin-svelte@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-3.0.0.tgz#1e6d98b465bb81db06efca43ed55abb2b3daec64"
@@ -3244,10 +3258,22 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+s.color@0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/s.color/-/s.color-0.0.15.tgz#6b32cd22d8dba95703a5122ddede2020a1560186"
+  integrity sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==
+
 safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+sass-formatter@^0.7.6:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/sass-formatter/-/sass-formatter-0.7.8.tgz#7b648f91e502cd783119eee3c8fffea0d4e07265"
+  integrity sha512-7fI2a8THglflhhYis7k06eUf92VQuJoXzEs2KRP0r1bluFxKFvLx0Ns7c478oYGM0fPfrr846ZRWVi2MAgHt9Q==
+  dependencies:
+    suf-log "^2.5.3"
 
 "semver@2 || 3 || 4 || 5":
   version "5.7.2"
@@ -3465,6 +3491,13 @@ stylelint@^15.8.0:
     svg-tags "^1.0.0"
     table "^6.8.1"
     write-file-atomic "^5.0.1"
+
+suf-log@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/suf-log/-/suf-log-2.5.3.tgz#0919a7fceea532a99b578c97814c4e335b2d64d1"
+  integrity sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==
+  dependencies:
+    s.color "0.0.15"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
Fixes #332 

Adds a test for astro components (which are currently failing to parse) then adds astro components to the parser blocklist (which causes the test to pass, as they are skipped).

Astro component files are similar to all of the other blocked component files in that they may contain styles as well as markup, and they just happen to cause errors in styles parsing (the same error as Svelte components actually), so I think its reasonable to skip them for the same reasons as the other component types.