### PR TITLE
Improve debug message when json parsing fails in e2e tests

### DIFF
--- a/test/stylelint-prettier-e2e.test.js
+++ b/test/stylelint-prettier-e2e.test.js
@@ -113,8 +113,17 @@ function runStylelint(pattern) {
   const result = spawnSync(stylelintCmd, ['--formatter=json', pattern], {
     cwd: stylelintCwd,
   });
+  const resultContent = result.stderr.toString().trim();
 
-  const jsonErrors = JSON.parse(result.stderr.toString().trim());
+  let jsonErrors;
+  try {
+    jsonErrors = JSON.parse(resultContent);
+  } catch (err) {
+    throw new Error(
+      `Could not parse json from stderr. Attempted to parse:\n${resultContent}`,
+      {cause: err}
+    );
+  }
 
   const errorLines = [];
 


### PR DESCRIPTION
stylelint's e2e tests started failing in October per https://github.com/stylelint/stylelint-ecosystem-tester/issues/61

It looks like some node debug message is screwing the ability to parse the output of stderr when using `--json` as json, but the current message is highly truncated. I suspect this is new as a result of moving from node 20 to 22 for the the ecosystem tests.
I'm taking bets on it being a message regarding `require(esm)` usage in node_modules that will be silenced in the next v22 release - https://github.com/nodejs/node/pull/55217

The error we get is:
>  error: `Unexpected token '(', "(node:1985"... is not valid JSON`

Rethrow with the full content of stderr so we can see what is appearing that is causing this failure
