### PR TITLE
Add endIndex to parsing error report call

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,12 +127,17 @@ const ruleFunction = (expectation, options, context) => {
         message = message.replace(/ \(\d+:\d+\)$/, '');
       }
 
+      const startIndex = getIndexFromLoc(source, err.loc.start);
+
       stylelint.utils.report({
         ruleName,
         result,
         message,
         node: root,
-        index: getIndexFromLoc(source, err.loc.start),
+        index: startIndex,
+        endIndex: err.loc.end
+          ? getIndexFromLoc(source, err.loc.end)
+          : startIndex + 1,
       });
 
       return;


### PR DESCRIPTION
Fixes #383
Closes #384

Stylelint v16.13 and up raises a deprecation warning when you report with index but no endIndex.

Prettier may in some cases return a err.loc.end, use that if available, otherwise the error is a single character. It feels claim anything after that character is an error if prettier can't parse it.